### PR TITLE
Extracting Loofah Scrubber rules from Sipity

### DIFF
--- a/hesburgh-lib.gemspec
+++ b/hesburgh-lib.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency 'loofah', "~> 2.0.3"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/hesburgh/lib/html_scrubber.rb
+++ b/lib/hesburgh/lib/html_scrubber.rb
@@ -1,0 +1,120 @@
+require 'loofah'
+require 'loofah/scrubber'
+
+module Hesburgh
+  module Lib
+    # Exposes a consistent means of scrubbing HTML.
+    #
+    # @see Rails `sanitize` method
+    # @todo Extract to the Hesburgh::Lib gem
+    module HtmlScrubber
+      ALLOWED_INLINE_TAGS = %w(abbr acronym b big cit cite code dfn em i mark samp small strong sub sup time tt var).freeze
+      ALLOWED_INLINE_WITH_LINK_TAGS = (%w(a) + ALLOWED_INLINE_TAGS).freeze
+      ALLOWED_INLINE_ATTRIBUTES = %w(datetime title href rel dir).freeze
+      ALLOWED_BLOCK_ATTRIBUTES = ALLOWED_INLINE_ATTRIBUTES
+
+      # We want to render this information as part of the metadata of a page. Examples include the `html head title` attribute
+      def self.build_meta_tag_scrubber(tags: [], attributes: :fallback)
+        AllowedTagsScrubber.new(tags: tags, attributes: attributes)
+      end
+
+      # We expect a single line of content. Examples include a "title" of an item
+      def self.build_inline_scrubber(tags: ALLOWED_INLINE_TAGS, attributes: ALLOWED_INLINE_ATTRIBUTES)
+        AllowedTagsScrubber.new(tags: tags, attributes: attributes)
+      end
+
+      # We expect a single line of content but are allowing links (A-tags) to be included.
+      def self.build_inline_with_link_scrubber(tags: ALLOWED_INLINE_WITH_LINK_TAGS, attributes: ALLOWED_INLINE_ATTRIBUTES)
+        AllowedTagsScrubber.new(tags: tags, attributes: attributes)
+      end
+
+      # We are allowing multiple lines of content. Examples include an "abstract" of an item
+      def self.build_block_scrubber
+        AllowedTagsScrubber.new(tags: AllowedTagsScrubber::FALLBACK, attributes: ALLOWED_BLOCK_ATTRIBUTES)
+      end
+
+      # Responsible for stripping and general sanitization of HTML documents
+      class AllowedTagsScrubber < Loofah::Scrubber
+        FALLBACK = :fallback
+        # @param tags [Symbol, Array<String>] What are the tags we are we going to keep. Otherwise the tag (but not content) is stripped.
+        # @param attributes [Symbol, Array<String>] What are the attributes we are we going to keep? Otherwise the attribute and its value
+        #                                           are dropped.
+        # @param direction [Symbol] How are we processing the nodes; This is an assumption based on the Loofah::Scrubber
+        def initialize(tags: FALLBACK, attributes: FALLBACK, direction: :bottom_up)
+          self.direction = direction
+          self.tags = tags
+          self.attributes = attributes
+        end
+
+        # A convenience method for sanitiziation
+        def sanitize(input)
+          return '' if input.to_s.strip == ''
+          return input unless input.is_a?(String)
+          Loofah.fragment(input).scrub!(self).to_s.strip
+        end
+        alias call sanitize
+
+        def scrub(node)
+          return node.remove if script_node?(node)
+          if node_allowed?(node)
+            scrub_node_attributes(node)
+            return CONTINUE
+          else
+            node.before node.children
+            node.remove
+          end
+        end
+
+        private
+
+        attr_reader :tags, :attributes
+        attr_accessor :direction
+
+        def tags=(input)
+          @tags = extract_with_fallback_consideration(input)
+        end
+
+        def attributes=(input)
+          @attributes = extract_with_fallback_consideration(input)
+        end
+
+        def extract_with_fallback_consideration(input)
+          return FALLBACK if input == FALLBACK
+          Array.wrap(input)
+        end
+
+        def script_node?(node)
+          node.name == 'script'
+        end
+
+        def scrub_node_attributes(node)
+          return fallback_scrub_node_attributes(node) if attributes == FALLBACK
+          node.attribute_nodes.each do |attr_node|
+            attr_node.remove unless attributes.include?(attr_node.name)
+          end
+        end
+
+        def allowed_not_element_node_types
+          [Nokogiri::XML::Node::TEXT_NODE, Nokogiri::XML::Node::CDATA_SECTION_NODE]
+        end
+
+        def fallback_scrub_node_attributes(node)
+          Loofah::HTML5::Scrub.scrub_attributes(node)
+          true
+        end
+
+        def fallback_allowed_element_detection(node)
+          Loofah::HTML5::Scrub.allowed_element?(node.name)
+        end
+
+        def node_allowed?(node)
+          return fallback_allowed_element_detection(node) if tags == FALLBACK
+          return true if allowed_not_element_node_types.include?(node.type)
+          return false unless node.type == Nokogiri::XML::Node::ELEMENT_NODE
+          tags.include?(node.name)
+        end
+      end
+      private_constant :AllowedTagsScrubber
+    end
+  end
+end

--- a/spec/lib/hesburgh/lib/html_scrubber_spec.rb
+++ b/spec/lib/hesburgh/lib/html_scrubber_spec.rb
@@ -1,0 +1,165 @@
+require 'spec_helper'
+require 'hesburgh/lib/html_scrubber'
+require 'active_support/core_ext/array/wrap'
+
+RSpec.describe Hesburgh::Lib::HtmlScrubber do
+  context '.build_inline_scrubber' do
+    subject { described_class.build_inline_scrubber }
+    it { is_expected.to respond_to(:call) }
+    {
+      nil => '',
+      ' ' => '',
+      Date.new(2015, 10, 1) => Date.new(2015, 10, 1),
+      %( <p>Hello</p> ) => %(Hello),
+      %(<p>Hello</p>) => %(Hello),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(Hello World),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World <i>Are we there yet?</i>)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+
+    context 'with tags: :fallback' do
+      subject { described_class.build_inline_scrubber(tags: :fallback) }
+      {
+        nil => '',
+        ' ' => '',
+        %( <p>Hello</p> ) => %(<p>Hello</p>),
+        %(<p>Hello</p>) => %(<p>Hello</p>),
+        %(Hello) => %(Hello),
+        %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+        %(<script><i>Hello</i></script>) => %(),
+        %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(<p>Hello <a href="http://world.com">World</a></p>),
+        %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello <p>World <i>Are we there yet?</i></p>)
+      }.each do |input, expected|
+        it "will scrub #{input.inspect} into #{expected.inspect}" do
+          expect(subject.sanitize(input)).to eq(expected)
+        end
+      end
+    end
+
+    context 'with attributes: :fallback' do
+      subject { described_class.build_inline_scrubber(attributes: :fallback) }
+      {
+        nil => '',
+        ' ' => '',
+        %( <p>Hello</p> ) => %(Hello),
+        %(<p>Hello</p>) => %(Hello),
+        %(Hello) => %(Hello),
+        %(<script><i>Hello</i></script>) => %(),
+        %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+        %(<p>Hello World</a></p>) => %(Hello World),
+        %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World <i>Are we there yet?</i>)
+      }.each do |input, expected|
+        it "will scrub #{input.inspect} into #{expected.inspect}" do
+          expect(subject.sanitize(input)).to eq(expected)
+        end
+      end
+    end
+  end
+
+  context '.build_inline_with_link_scrubber' do
+    subject { described_class.build_inline_with_link_scrubber }
+    it { is_expected.to respond_to(:call) }
+    {
+      nil => '',
+      ' ' => '',
+      Date.new(2015, 10, 1) => Date.new(2015, 10, 1),
+      %( <p>Hello</p> ) => %(Hello),
+      %(<p>Hello</p>) => %(Hello),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(Hello <a href="http://world.com">World</a>),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World <i>Are we there yet?</i>)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+
+    context 'with tags: :fallback' do
+      subject { described_class.build_inline_with_link_scrubber(tags: :fallback) }
+      {
+        nil => '',
+        ' ' => '',
+        %( <p>Hello</p> ) => %(<p>Hello</p>),
+        %(<p>Hello</p>) => %(<p>Hello</p>),
+        %(Hello) => %(Hello),
+        %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+        %(<script><i>Hello</i></script>) => %(),
+        %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(<p>Hello <a href="http://world.com">World</a></p>),
+        %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello <p>World <i>Are we there yet?</i></p>)
+      }.each do |input, expected|
+        it "will scrub #{input.inspect} into #{expected.inspect}" do
+          expect(subject.sanitize(input)).to eq(expected)
+        end
+      end
+    end
+
+    context 'with attributes: :fallback' do
+      subject { described_class.build_inline_with_link_scrubber(attributes: :fallback) }
+      {
+        nil => '',
+        ' ' => '',
+        %( <p>Hello</p> ) => %(Hello),
+        %(<p>Hello</p>) => %(Hello),
+        %(Hello) => %(Hello),
+        %(<script><i>Hello</i></script>) => %(),
+        %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+        %(<p>Hello World</a></p>) => %(Hello World),
+        %(<p>H <a href="http://world.com" target="_blank">W</a></p>) => %(H <a href="http://world.com" target="_blank">W</a>),
+        %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World <i>Are we there yet?</i>)
+      }.each do |input, expected|
+        it "will scrub #{input.inspect} into #{expected.inspect}" do
+          expect(subject.sanitize(input)).to eq(expected)
+        end
+      end
+    end
+  end
+  context '.build_block_scrubber' do
+    subject { described_class.build_block_scrubber }
+    it { is_expected.to respond_to(:call) }
+    {
+      nil => '',
+      ' ' => '',
+      %( <p>Hello</p> ) => %(<p>Hello</p>),
+      %(<p>Hello</p>) => %(<p>Hello</p>),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(<p>Hello <a href="http://world.com">World</a></p>),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello <p>World <i>Are we there yet?</i></p>),
+      # Because you should know how the scrubber will obliterate and interact with the HTML tag delimiters
+      %(Hello < World > Where Are < You > Do You Know >) => %(Hello  Where Are  Do You Know &gt;)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+  end
+
+  context '.build_meta_tag_scrubber' do
+    subject { described_class.build_meta_tag_scrubber }
+    it { is_expected.to respond_to(:call) }
+    {
+      nil => '',
+      ' ' => '',
+      %( <p>Hello</p> ) => %(Hello),
+      %(<p>Hello</p>) => %(Hello),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(Hello),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(Hello World),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World Are we there yet?)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are rules that we will almost certainly wish to share between
Sipity and Curate.